### PR TITLE
Add bash/make based alternative to bumpversion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 build-harness.iml
 .build-harness.venv
 .build-harness.requirements.txt
+.build-harness.Pipfile*

--- a/modules/git/Makefile
+++ b/modules/git/Makefile
@@ -11,18 +11,20 @@ git/aliases-update:
 
 ## Export git vars
 git/export:
-	@echo "GIT_COMMIT=$(GIT_COMMIT)"
-	@echo "GIT_COMMIT_SHORT=$(GIT_COMMIT_SHORT)"
-	@echo "GIT_COMMIT_TIMESTAMP=$(GIT_COMMIT_TIMESTAMP)"
-	@echo "GIT_COMMIT_URL=$(GIT_COMMIT_URL)"
-	@echo "GIT_COMMIT_MESSAGE=$(GIT_COMMIT_MESSAGE)"
-	@echo "GIT_COMMIT_AUTHOR=$(GIT_COMMIT_AUTHOR)"
-	@echo "GIT_BRANCH=$(GIT_BRANCH)"
-	@echo "GIT_TAG=$(GIT_TAG)"
-	@echo "GIT_BRANCH_TAG=$(GIT_BRANCH_TAG)"
-	@echo "GIT_IS_BRANCH=$(GIT_IS_BRANCH)"
-	@echo "GIT_IS_TAG=$(GIT_IS_TAG)"
-	@echo "GIT_TIMESTAMP=$(GIT_TIMESTAMP)"
+	$(call print-var,GIT_COMMIT)
+	$(call print-var,GIT_COMMIT_SHORT)
+	$(call print-var,GIT_COMMIT_TIMESTAMP)
+	$(call print-var,GIT_COMMIT_URL)
+	$(call print-var,GIT_COMMIT_MESSAGE)
+	$(call print-var,GIT_COMMIT_AUTHOR)
+	$(call print-var,GIT_BRANCH)
+	$(call print-var,GIT_TAG)
+	$(call print-var,GIT_LATEST_TAG)
+	$(call print-var,GIT_LATEST_TAG_COMMIT)
+	$(call print-var,GIT_LATEST_SEMVER_TAG)
+	$(call print-var,GIT_BRANCH_TAG)
+	$(call print-var,GIT_IS_BRANCH)
+	$(call print-var,GIT_IS_TAG)
 
 ## Build .gitignore file if one doesn't exist
 git/ignore:

--- a/modules/git/Makefile
+++ b/modules/git/Makefile
@@ -46,7 +46,7 @@ git/ignore:
 
 
 git/require_master:
-	@if [ $$(git rev-parse --abbrev-ref HEAD) != "master" ]; then\
+	@if [ ${GIT_BRANCH} != "master" ]; then\
 		echo "You are not on master.";\
-		exit 0;\
+		exit 1;\
 	fi

--- a/modules/git/Makefile
+++ b/modules/git/Makefile
@@ -1,5 +1,4 @@
-GIT:= $(shell which git 2>/dev/null)
-GITIGNORE_TARGETS ?= python
+GITIGNORE_TARGETS ?= python,golang
 
 ## Update submodules
 git/submodules-update:

--- a/modules/git/bootstrap.Makefile
+++ b/modules/git/bootstrap.Makefile
@@ -4,21 +4,20 @@ ifeq ($(wildcard .git),)
   endif
 else
 
-GIT ?= $(shell which git)
+GIT?=$(shell which git)
 
 export GIT_COMMIT ?= $(shell $(GIT) rev-parse --verify HEAD 2>/dev/null)
 export GIT_COMMIT_SHORT ?= $(shell $(GIT) rev-parse --verify --short HEAD 2>/dev/null)
 export GIT_BRANCH ?= $(shell $(GIT) rev-parse --abbrev-ref HEAD 2>/dev/null)
 export GIT_TAG ?= $(shell $(GIT) tag -l --sort -taggerdate --points-at HEAD 2>/dev/null | head -n 1)
+export GIT_LATEST_TAG ?= $(shell $(GIT) describe --tags --abbrev=0 $(git rev-list --tags --max-count=1) 2>/dev/null)
+export GIT_LATEST_TAG_COMMIT ?= $(shell $(GIT) rev-list --tags --max-count=1)
+export GIT_LATEST_SEMVER_TAG ?= $(shell $(GIT) describe --tags --exact-match --match '[0-9\.]*' $$($(GIT) rev-list --tags --max-count=1) 2>/dev/null)
 export GIT_COMMIT_URL ?= $(shell $(GIT) config --get remote.origin.url 2>/dev/null | sed 's/\.git$$//g' | sed 's/git@\(.*\):/https:\/\/\1\//g' )/commit/$(GIT_COMMIT_SHORT)
 
 export GIT_COMMIT_MESSAGE ?= $(shell $(GIT) show -s --format=%s%b 2>/dev/null)
 export GIT_COMMIT_AUTHOR ?= $(shell $(GIT) show -s --format=%aN 2>/dev/null)
 export GIT_COMMIT_TIMESTAMP ?= $(shell $(GIT) log -1 --format=%ct 2>/dev/null)
-
-
-## GIT_TIMESTAMP is deprecated. Use GIT_COMMIT_TIMESTAMP instead
-export GIT_TIMESTAMP ?= $(shell $(GIT) log -1 --format=%ct 2>/dev/null)
 
 ifeq ($(GIT_TAG),)
   export GIT_IS_TAG := 0

--- a/modules/semver/Makefile
+++ b/modules/semver/Makefile
@@ -1,56 +1,32 @@
-ifneq ($(wildcard .git),)
-## Array of all possible versions based on this git commit
-SEMVERSIONS :=
+SEMVER_REGEX:=([0-9]*)[.]([0-9]*)[.]([0-9]*)
+define semver-part
+$(shell echo "$(1)" | sed -E 's/$(SEMVER_REGEX)/\$(2)/' )
+endef
 
-## Version based on short commit. ex.: 0.0.0-sha.80b9f6f
-SEMVERSION_COMMIT_SHORT = 0.0.0-sha.$(GIT_COMMIT_SHORT)
-SEMVERSIONS += $(SEMVERSION_COMMIT_SHORT)
-
-## Version based on long commit. ex.: 0.0.0-sha.80b9f6f5b965555e406b9db066a8e16cb1075e5f
-SEMVERSION_COMMIT = 0.0.0-sha.$(GIT_COMMIT)
-SEMVERSIONS += $(SEMVERSION_COMMIT)
-
-## If we are on git tag. ex.: 0.3.1
-SEMVERSION_TAG =
-
-ifeq ($(GIT_IS_TAG),1)
-  ## Version based on tag. ex.: 0.3.1
-  SEMVERSION_TAG = $(subst /,-,$(GIT_TAG))
-  SEMVERSIONS += $(SEMVERSION_TAG)
+ifneq ($(GIT_LATEST_SEMVER_TAG),)
+SEMVER_MAJOR:=$(call semver-part,$(GIT_LATEST_SEMVER_TAG),1)
+SEMVER_MINOR:=$(call semver-part,$(GIT_LATEST_SEMVER_TAG),2)
+SEMVER_PATCH:=$(call semver-part,$(GIT_LATEST_SEMVER_TAG),3)
+else
+SEMVER_MAJOR?=0
+SEMVER_MINOR?=0
+SEMVER_PATCH?=0
 endif
 
-## If we are on git branch. ex.: master
-SEMVERSION_BRANCH=
-SEMVERSION_BRANCH_COMMIT_SHORT=
-SEMVERSION_BRANCH_COMMIT=
-
-ifeq ($(GIT_IS_BRANCH),1)
-  ## Version based on branch. ex.: 0.0.0-master
-  SEMVERSION_BRANCH = 0.0.0-$(subst /,-,$(GIT_BRANCH))
-  SEMVERSIONS += $(SEMVERSION_BRANCH)
-
-  ## Version based on branch and short commit. ex.: 0.0.0-master.sha.80b9f6f
-  SEMVERSION_BRANCH_COMMIT_SHORT = $(SEMVERSION_BRANCH).sha.$(GIT_COMMIT_SHORT)
-  SEMVERSIONS += $(SEMVERSION_BRANCH_COMMIT_SHORT)
-
-  ## Version based on branch and long commit. ex.: 0.0.0-master.sha.80b9f6f5b965555e406b9db066a8e16cb1075e5f
-  SEMVERSION_BRANCH_COMMIT = $(SEMVERSION_BRANCH).sha.$(GIT_COMMIT)
-  SEMVERSIONS += $(SEMVERSION_BRANCH_COMMIT)
-endif
-
-## Use as default version first of possible versions
-export SEMVERSION ?= $(word 1,$(SEMVERSIONS))
-
-## Export semver vars
 semver/export:
-	@echo "SEMVERSION_COMMIT_SHORT=$(SEMVERSION_COMMIT_SHORT)"
-	@echo "SEMVERSION_COMMIT=$(SEMVERSION_COMMIT)"
-	@echo "SEMVERSION_BRANCH=$(SEMVERSION_BRANCH)"
-	@echo "SEMVERSION_BRANCH_COMMIT_SHORT=$(SEMVERSION_BRANCH_COMMIT_SHORT)"
-	@echo "SEMVERSION_BRANCH_COMMIT=$(SEMVERSION_BRANCH_COMMIT)"
-	@echo "SEMVERSION_TAG=$(SEMVERSION_TAG)"
+	$(call print-var,GIT_LATEST_SEMVER_TAG)
+	$(call print-var,SEMVER_MAJOR)
+	$(call print-var,SEMVER_MINOR)
+	$(call print-var,SEMVER_PATCH)
 
-else ifeq ($(DEBUG),true)
-  $(warning disabled semver processing)
-endif
+define semver
+$(shell echo $(if $(filter major,$(1)),$$(($(SEMVER_MAJOR) + 1)).0.0,)$(if $(filter minor,$(1)),$(SEMVER_MAJOR).$$(($(SEMVER_MINOR) + 1)).0,)$(if $(filter patch,$(1)),$(SEMVER_MAJOR).$(SEMVER_MINOR).$$(($(SEMVER_PATCH) + 1)),))
+endef
 
+semver:
+	@echo "$(shell basename -s .git `$(GIT) config --get remote.origin.url`) $(GIT_LATEST_SEMVER_TAG)"
+
+semver/%: git/require_master
+	@echo "Bumping the $* version $(GIT_LATEST_SEMVER_TAG) -> $(call semver,$*)"
+	@$(GIT) tag -a $(call semver,$*) -m "bump version $(GIT_LATEST_SEMVER_TAG) -> $(call semver,$*)"
+	@$(GIT) push --follow-tags

--- a/modules/semver/Makefile
+++ b/modules/semver/Makefile
@@ -23,12 +23,15 @@ define semver
 $(shell echo $(if $(filter major,$(1)),$$(($(SEMVER_MAJOR) + 1)).0.0,)$(if $(filter minor,$(1)),$(SEMVER_MAJOR).$$(($(SEMVER_MINOR) + 1)).0,)$(if $(filter patch,$(1)),$(SEMVER_MAJOR).$(SEMVER_MINOR).$$(($(SEMVER_PATCH) + 1)),))
 endef
 
-semver:
+semver/check:
+	$(call assert-set,GIT_LATEST_SEMVER_TAG)
+
+semver: semver/check
 	@echo "$(shell basename -s .git `$(GIT) config --get remote.origin.url`) $(GIT_LATEST_SEMVER_TAG)"
 
 semver/announce/%:
 	@echo "Bumping the $* version $(GIT_LATEST_SEMVER_TAG) -> $(call semver,$*)"
 
-semver/%: git/require_master semver/announce/$*
+semver/%: git/require_master semver/check semver/announce/$*
 	@$(GIT) tag -a $(call semver,$*) -m "bump version $(GIT_LATEST_SEMVER_TAG) -> $(call semver,$*)"
 	@$(GIT) push --follow-tags

--- a/modules/semver/Makefile
+++ b/modules/semver/Makefile
@@ -26,7 +26,9 @@ endef
 semver:
 	@echo "$(shell basename -s .git `$(GIT) config --get remote.origin.url`) $(GIT_LATEST_SEMVER_TAG)"
 
-semver/%: git/require_master
+semver/announce/%:
 	@echo "Bumping the $* version $(GIT_LATEST_SEMVER_TAG) -> $(call semver,$*)"
+
+semver/%: git/require_master semver/announce/$*
 	@$(GIT) tag -a $(call semver,$*) -m "bump version $(GIT_LATEST_SEMVER_TAG) -> $(call semver,$*)"
 	@$(GIT) push --follow-tags


### PR DESCRIPTION
```
> $ make semver semver/announce/major semver/announce/minor semver/announce/patch
build-harness 1.0.0
Bumping the major version 1.0.0 -> 2.0.0
Bumping the minor version 1.0.0 -> 1.1.0
Bumping the patch version 1.0.0 -> 1.0.1
```